### PR TITLE
Do not escape Sauce Connect destination folder

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,8 @@ dependencies:
 
 test:
   override:
-    - ./bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -f ~/sc_ready:
+    - cd sc-*-linux && ./bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -f ~/sc_ready:
         background: true
-        pwd: sc-*-linux
     # Wait for tunnel to be ready
     - while [ ! -e ~/sc_ready ]; do sleep 1; done
     - python -m hello.hello_app:


### PR DESCRIPTION
`pwd: sc-*-linux` results in Circle in `cd "sc-*-linux"`, which isn't escaped by the shell, while the `*` was there to avoid having to update your `circle.yml` on each Sauce Connect updates (it resolves, for example, to `sc-4.3-linux`).